### PR TITLE
Fix error in examples

### DIFF
--- a/src/local-chain-sync.ts
+++ b/src/local-chain-sync.ts
@@ -34,11 +34,8 @@ class Database {
     }
 }
 
-const replacer = (_key: any, block: Block) => {
-    // Avoids error when serializing BigInt
-    delete block['transactions'];
-    return block;
-}
+// Avoids error when serializing BigInt
+const replacer = (_key: any, value: any) => typeof value === 'bigint' ? value.toString() : value;
 
 const rollForward = (db : Database) => async ({ block }: { block: Block }, requestNextBlock: () => void) => {
     console.log(`Roll forward: ${JSON.stringify(block, replacer)}`);

--- a/src/local-chain-sync.ts
+++ b/src/local-chain-sync.ts
@@ -34,8 +34,14 @@ class Database {
     }
 }
 
+const replacer = (_key: any, block: Block) => {
+    // Avoids error when serializing BigInt
+    delete block['transactions'];
+    return block;
+}
+
 const rollForward = (db : Database) => async ({ block }: { block: Block }, requestNextBlock: () => void) => {
-    console.log(`Roll forward: ${JSON.stringify(block)}`);
+    console.log(`Roll forward: ${JSON.stringify(block, replacer)}`);
     db.rollForward(block);
     requestNextBlock();
 }

--- a/src/local-mempool-monitor.ts
+++ b/src/local-mempool-monitor.ts
@@ -13,7 +13,9 @@ async function flushMempool(
     client: MempoolMonitoring.MempoolMonitoringClient
 ): Promise<TransactionId[]> {
     let transactions = [];
-    for(let transactionId = await client.nextTransaction();;) {
+
+    for(;;){
+        const transactionId = await client.nextTransaction();
         if (transactionId !== null) {
             transactions.push(transactionId);
         } else {


### PR DESCRIPTION
Fixes errors in _local-chain-sync_ and _local-mempool-monitor_ examples. Using ogmios v6.0.0-rc6.

1. local-chain-sync

The following error is thrown when attempting to stringify a Block

```
console.log(`Roll forward: ${JSON.stringify(block)}`);
                                  ^
TypeError: Do not know how to serialize a BigInt
```

Explicitly stringifying when value is BigInt fixes this.

2. local-mempool-monitor

Calling `await client.nextTransaction()` from inside the for loop's initialization section would always yield the same result. Changing it to be called from inside the loop fixes the issue.